### PR TITLE
Update CODEOWNERS to project maintainers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -20,4 +20,4 @@
 # .pre-commit-config.yaml @wusatosi # Add other project owners here
 # .markdownlint.yaml @wusatosi # Add other project owners here
 
-*  @bretbrownjr @camio @dietmarkuehl @neatudarius @steve-downey @wusatosi
+*  @robert-andrzejuk @JeffGarland @wusatosi


### PR DESCRIPTION
Reflect current maintainers.

And avoid spamming exemplar's CODEOWNERs regarding everything happening here.