### PR TITLE
Delegate implementation to std::experimental

### DIFF
--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -20,14 +20,6 @@ jobs:
             platform: "ubuntu-latest"
           - preset: "gcc-release"
             platform: "ubuntu-latest"
-          - preset: "appleclang-debug"
-            platform: "macos-latest"
-          - preset: "appleclang-release"
-            platform: "macos-latest"
-          - preset: "msvc-debug"
-            platform: "windows-latest"
-          - preset: "msvc-release"
-            platform: "windows-latest"
     name: "Preset: ${{ matrix.presets.preset }} on ${{ matrix.presets.platform }}"
     runs-on: ${{ matrix.presets.platform }}
     steps:
@@ -56,13 +48,7 @@ jobs:
           - description: "Ubuntu LLVM"
             os: ubuntu-latest
             toolchain: "cmake/llvm-toolchain.cmake"
-          - description: "Windows MSVC"
-            os: windows-latest
-            toolchain: "cmake/msvc-toolchain.cmake"
-          - description: "Macos Appleclang"
-            os: macos-latest
-            toolchain: "cmake/appleclang-toolchain.cmake"
-        cpp_version: [17, 20, 23, 26]
+        cpp_version: [20, 23, 26]
         cmake_args:
           - description: "Default"
           - description: "TSan"
@@ -74,7 +60,7 @@ jobs:
               description: "Ubuntu GCC"
               os: ubuntu-latest
               toolchain: "cmake/gnu-toolchain.cmake"
-            cpp_version: 17
+            cpp_version: 20
             cmake_args:
               description: "Werror"
               args: "-DCMAKE_CXX_FLAGS='-Werror=all -Werror=extra'"
@@ -82,16 +68,10 @@ jobs:
               description: "Ubuntu GCC"
               os: ubuntu-latest
               toolchain: "cmake/gnu-toolchain.cmake"
-            cpp_version: 17
+            cpp_version: 20
             cmake_args:
               description: "Dynamic"
               args: "-DBUILD_SHARED_LIBS=on"
-        exclude:
-            # MSVC does not support thread sanitizer
-          - platform:
-              description: "Windows MSVC"
-            cmake_args:
-              description: "TSan"
 
     name: "Unit: ${{ matrix.platform.description }} ${{ matrix.cpp_version }} ${{ matrix.cmake_args.description }}"
     runs-on: ${{ matrix.platform.os }}
@@ -192,16 +172,10 @@ jobs:
             version: 14
           - class: GNU
             version: 13
-          - class: GNU
-            version: 12
           - class: LLVM
             version: 20
           - class: LLVM
             version: 19
-          - class: LLVM
-            version: 18
-          - class: LLVM
-            version: 17
     name: "Compiler: ${{ matrix.compilers.class }} ${{ matrix.compilers.version }}"
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -176,12 +176,16 @@ jobs:
         compilers:
           - class: GNU
             version: 14
+            toolchain: "cmake/gnu-toolchain.cmake"
           - class: GNU
             version: 13
+            toolchain: "cmake/gnu-toolchain.cmake"
           - class: LLVM
             version: 20
+            toolchain: "cmake/llvm-toolchain.cmake"
           - class: LLVM
             version: 19
+            toolchain: "cmake/llvm-toolchain.cmake"
     name: "Compiler: ${{ matrix.compilers.class }} ${{ matrix.compilers.version }}"
     steps:
       - uses: actions/checkout@v4
@@ -202,8 +206,10 @@ jobs:
             sudo apt-get install -y $CC
             sudo apt-get install -y $CXX
 
-            $CC --version
-            $CXX --version
+            sudo ln -sf "$(which $CC)" /usr/bin/gcc
+            sudo ln -sf "$(which $CXX)" /usr/bin/g++
+
+            /usr/bin/g++ --version
           else
             wget https://apt.llvm.org/llvm.sh
             chmod +x llvm.sh
@@ -212,18 +218,15 @@ jobs:
             CC=clang-${{ matrix.compilers.version }}
             CXX=clang++-${{ matrix.compilers.version }}
 
-            $CC --version
-            $CXX --version
-          fi
+            sudo ln -sf "$(which $CC)" /usr/bin/clang
+            sudo ln -sf "$(which $CXX)" /usr/bin/clang++
 
-          echo "CC=$CC" >> "$GITHUB_OUTPUT"
-          echo "CXX=$CXX" >> "$GITHUB_OUTPUT"
+            /usr/bin/clang++ --version
+          fi
       - name: Configure CMake
         run: |
-          cmake -B build -S . -DCMAKE_CXX_STANDARD=20
+          cmake -B build -S . -DCMAKE_CXX_STANDARD=20 -DCMAKE_TOOLCHAIN_FILE="${{ matrix.compilers.toolchain }}"
         env:
-          CC: ${{ steps.install-compiler.outputs.CC }}
-          CXX: ${{ steps.install-compiler.outputs.CXX }}
           CMAKE_GENERATOR: "Ninja Multi-Config"
       - name: Build Debug
         run: |

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -144,7 +144,7 @@ jobs:
           ninja --version
       - name: Configure CMake
         run: |
-          cmake -B build -S . -DCMAKE_CXX_STANDARD=17 ${{ matrix.args.arg }}
+          cmake -B build -S . -DCMAKE_CXX_STANDARD=20 -DCMAKE_TOOLCHAIN_FILE="cmake/gnu-toolchain.cmake" ${{ matrix.args.arg }}
         env:
           CMAKE_GENERATOR: "Ninja Multi-Config"
       - name: Build Release

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -89,7 +89,10 @@ jobs:
           arch: x64
       - name: Setup LLVM
         if: matrix.platform.toolchain == 'cmake/llvm-toolchain.cmake'
-        run: sudo bash -c "$(wget -O - https://apt.llvm.org/llvm.sh)"
+        run: |
+          wget https://apt.llvm.org/llvm.sh
+          chmod +x llvm.sh
+          sudo bash llvm.sh 19
       - name: Setup Macos
         if: startsWith(matrix.platform.os, 'macos')
         run: sudo chmod -R 777 /opt/

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -93,6 +93,9 @@ jobs:
           wget https://apt.llvm.org/llvm.sh
           chmod +x llvm.sh
           sudo bash llvm.sh 19
+
+          sudo ln -sf "$(which clang-19)" /usr/bin/clang
+          sudo ln -sf "$(which clang++-19)" /usr/bin/clang++
       - name: Setup Macos
         if: startsWith(matrix.platform.os, 'macos')
         run: sudo chmod -R 777 /opt/

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -87,6 +87,9 @@ jobs:
         uses: TheMrMilchmann/setup-msvc-dev@v3
         with:
           arch: x64
+      - name: Setup LLVM
+        if: matrix.platform.toolchain == 'cmake/llvm-toolchain.cmake'
+        run: sudo bash -c "$(wget -O - https://apt.llvm.org/llvm.sh)"
       - name: Setup Macos
         if: startsWith(matrix.platform.os, 'macos')
         run: sudo chmod -R 777 /opt/

--- a/include/beman/scope/scope.hpp
+++ b/include/beman/scope/scope.hpp
@@ -3,6 +3,11 @@
 #ifndef BEMAN_SCOPE_HPP
 #define BEMAN_SCOPE_HPP
 
+#include <type_traits>
+#include <utility>
+
+#include <experimental/scope>
+
 namespace beman::scope {
 
 // -- 7.6.7 Feature test macro --
@@ -13,22 +18,39 @@ namespace beman::scope {
 // -- 7.5.1 Header <scope> synopsis [scope.syn] --
 //
 //        namespace std {
+
 //        template <class EF>
 //        class scope_exit;
-//
+template <class EF>
+using scope_exit = std::experimental::scope_exit<EF>;
+
 //        template <class EF>
 //        class scope_fail;
-//
+template <class EF>
+using scope_fail = std::experimental::scope_fail<EF>;
+
 //        template <class EF>
 //        class scope_success;
-//
+template <class EF>
+using scope_success = std::experimental::scope_success<EF>;
+
 //        template <class R, class D>
 //        class unique_resource;
-//
+template <class R, class D>
+using unique_resource = std::experimental::unique_resource<R, D>;
+
 //        // factory function
 //        template <class R, class D, class S = decay_t<R>>
 //        unique_resource<decay_t<R>, decay_t<D>>
 //        make_unique_resource_checked(R&& r, const S& invalid, D&& d) noexcept(see below);
+
+template <class R, class D, class S = std::decay_t<R>>
+unique_resource<std::decay_t<R>, std::decay_t<D>>
+make_unique_resource_checked(R&& r, const S& invalid, D&& d) noexcept(noexcept(
+    std::experimental::make_unique_resource_checked(std::forward(r), std::forward(invalid), std::forward(d)))) {
+    return std::experimental::make_unique_resource_checked(std::forward(r), std::forward(invalid), std::forward(d));
+}
+
 //        } // namespace std
 //
 
@@ -59,7 +81,6 @@ namespace beman::scope {
 //        template <class EF>
 //        scope_guard(EF) -> scope_guard<EF>;
 //
-
 // -- 7.6.1 Class template unique_resource [scope.unique_resource.class] --
 //
 //        template <class R, class D>
@@ -92,33 +113,6 @@ namespace beman::scope {
 //
 //        template <typename R, typename D>
 //        unique_resource(R, D) -> unique_resource<R, D>;
-
-// TODO: Implement
-struct scope_exit {
-    template <typename F>
-    scope_exit(F) {}
-    ~scope_exit() {
-        // TODO: Cleanup
-    }
-};
-
-// TODO: Implement
-struct scope_fail {
-    template <typename F>
-    scope_fail(F) {}
-    ~scope_fail() {
-        // TODO: Cleanup
-    }
-};
-
-// TODO: Implement
-struct scope_success {
-    template <typename F>
-    scope_success(F) {}
-    ~scope_success() {
-        // TODO: Cleanup
-    }
-};
 
 } // namespace beman::scope
 


### PR DESCRIPTION
Delegate implementation detail to `std::experimental`.

Note that this removes support for

- apple clang
- msvc
- LLVM version < 19 (latest default stable for llvm install script is 18, this very much require the front-line release of LLVM)
- GCC version < 12

This is the complication I was complaining about in #3 .

This also means our project currently only support > C++20.

- [ ] We should document this compiler requirement