### PR TITLE
Update CODEOWNERS: remove deprecated group

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -20,4 +20,4 @@
 # .pre-commit-config.yaml @wusatosi # Add other project owners here
 # .markdownlint.yaml @wusatosi # Add other project owners here
 
-*  @robert-andrzejuk @JeffGarland @wusatosi @bemanproject/core-reviewers
+*  @robert-andrzejuk @JeffGarland @wusatosi @neatudarius


### PR DESCRIPTION
Update CODEOWNERS: remove deprecated group https://github.com/bemanproject/beman/blob/main/docs/BEMAN_STANDARD.md#repositorycodeowners

(add myself, I would like to help)