### PR TITLE
Enable beman-tidy --require-all (disable readme.implements until P3610)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -46,5 +46,6 @@ repos:
     rev: v0.4.0
     hooks:
     - id: beman-tidy
+      args: [".", "--verbose", "--require-all"]
 
 exclude: 'infra/'

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ SPDX-License-Identifier: CC0-1.0
 
 `beman.scope` is a C++ library that provides `scope_guard` facilities. The library conforms to [The Beman Standard](https://github.com/bemanproject/beman/blob/main/docs/beman_standard.md).
 
-**Implements**: [D3610R0 Scope Guard](./papers/scope.org) targeted at C++29.
+**Implements**: [Scope Guard (P3610R0)](https://wg21.link/P3610R0) targeted at C++29. Note: Paper not yet uploaded on WG21. The local draft is available at [./papers/scope.org](./papers/scope.org)
 
 **Status**: [Under development and not yet ready for production use.](https://github.com/bemanproject/beman/blob/main/docs/beman_library_maturity_model.md#under-development-and-not-yet-ready-for-production-use)
 


### PR DESCRIPTION
Superseded by #63 — see https://github.com/neatudarius/scope/tree/enable-tidy-require-all